### PR TITLE
Supports single & multiple commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.stack-work

--- a/README.md
+++ b/README.md
@@ -52,7 +52,31 @@ std dev              47.69 μs   (40.09 μs .. 57.91 μs)
 variance introduced by outliers: 81% (severely inflated)
 ```
 
-All output from the command being benchmarked is discarded
+All output from the command being benchmarked is discarded.
+
+Multiple commands are also supported:
+
+```bash
+$ bench id ls "sleep 0.1"
+benchmarking bench/id
+time                 4.798 ms   (4.764 ms .. 4.833 ms)
+                     0.999 R²   (0.998 R² .. 1.000 R²)
+mean                 4.909 ms   (4.879 ms .. 4.953 ms)
+std dev              104.6 μs   (78.91 μs .. 135.7 μs)
+
+benchmarking bench/ls
+time                 2.941 ms   (2.889 ms .. 3.006 ms)
+                     0.996 R²   (0.992 R² .. 0.998 R²)
+mean                 3.051 ms   (3.015 ms .. 3.094 ms)
+std dev              129.7 μs   (104.3 μs .. 178.3 μs)
+variance introduced by outliers: 25% (moderately inflated)
+
+benchmarking bench/sleep 0.1
+time                 109.9 ms   (108.5 ms .. 111.0 ms)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 109.2 ms   (108.5 ms .. 109.7 ms)
+std dev              903.0 μs   (676.4 μs .. 1.212 ms)
+```
 
 You can also output an HTML file graphing the distribution of
 timings by using the `--output` flag:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,27 +10,56 @@ import qualified Criterion
 import qualified Criterion.Main         as Criterion
 import qualified Criterion.Main.Options as Criterion
 import qualified Data.Text              as Text
+import qualified Text.Read              as Read
 import qualified System.IO              as IO
 import qualified System.IO.Silently     as Silently
 import qualified Turtle
 
+data Cmd
+    = Command Text
+    | Commands [Text]
+    deriving (Show)
+
+instance Read Cmd where
+    readsPrec d t  =
+        -- First attempt to read Commands: ["cmd", "cmd", ...]
+        case (Read.readMaybe t :: Maybe [Text]) of
+            Just t' -> [(Commands t', "")]
+            -- If that fails, fallback to Command
+            Nothing -> [(Command $ Text.pack t, "")]
+
 data Options = Options
-    { commands   :: [Text]
+    { cmd        :: Cmd
     , mode       :: Criterion.Mode
     } deriving (Show)
 
 parser :: Parser Options
 parser =
         Options
-    <$> Turtle.argRead "commands" "The command line to benchmark"
+    <$> Turtle.argRead "command(s)" "The command line(s) to benchmark"
     <*> Criterion.parseWith Criterion.defaultConfig
 
 main :: IO ()
 main = do
-    putStrLn "hi"
     o <- Turtle.options "Command-line tool to benchmark other programs" parser
-    print o
-    let ios       = map (\o' -> Turtle.shells o' empty) (commands o)
-    let benchmarks = map (\io -> Criterion.nfIO (Silently.hSilence [IO.stdout, IO.stderr] io)) ios
-    let benches    = map (\(command, benchmark) -> Criterion.bench (Text.unpack command) benchmark) $ zip (commands o) benchmarks
-    Criterion.runMode (mode o) [Criterion.bgroup "commands" benches]
+    case (cmd o) of
+      Command command   -> benchCommand command (mode o)
+      Commands commands -> benchCommands commands (mode o)
+
+benchCommands :: [Text] -> Criterion.Mode -> IO ()
+benchCommands commands mode = do
+    let benches = map (\command -> buildBench command mode) commands
+    Criterion.runMode mode [Criterion.bgroup "bench" benches]
+
+benchCommand :: Text -> Criterion.Mode -> IO ()
+benchCommand command mode = do
+    let bench = buildBench command mode
+    Criterion.runMode mode [ bench ]
+
+
+buildBench :: Text -> Criterion.Mode -> Criterion.Benchmark
+buildBench command mode = do
+    let io        = Turtle.shells command empty
+    let benchmark = Criterion.nfIO (Silently.hSilence [IO.stdout, IO.stderr] io)
+    let bench     = Criterion.bench (Text.unpack command) benchmark
+    bench

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,41 +11,27 @@ import qualified Criterion
 import qualified Criterion.Main         as Criterion
 import qualified Criterion.Main.Options as Criterion
 import qualified Data.Text              as Text
-import qualified Text.Read              as Read
 import qualified System.IO              as IO
 import qualified System.IO.Silently     as Silently
 import qualified Turtle
 
-data Cmd
-    = Command Text
-    | Commands [Text]
-    deriving (Show)
-
-instance Read Cmd where
-    readsPrec _ t  =
-        -- First attempt to read Commands: ["cmd", "cmd", ...]
-        case (Read.readMaybe t :: Maybe [Text]) of
-            Just t' -> [(Commands t', "")]
-            -- If that fails, fallback to Command
-            Nothing -> [(Command $ Text.pack t, "")]
-
 data Options = Options
-    { cmd        :: Cmd
+    { cmd        :: [Text]
     , mode       :: Criterion.Mode
     } deriving (Show)
 
 parser :: Parser Options
 parser =
         Options
-    <$> Turtle.argRead "command(s)" "The command line(s) to benchmark"
+    <$> some (Turtle.argText "command(s)" "The command line(s) to benchmark")
     <*> Criterion.parseWith Criterion.defaultConfig
 
 main :: IO ()
 main = do
     o <- Turtle.options "Command-line tool to benchmark other programs" parser
     case (cmd o) of
-      Command command   -> benchCommand command o
-      Commands commands -> benchCommands commands o
+      [command] -> benchCommand command o
+      commands  -> benchCommands commands o
 
 benchCommands :: [Text] -> Options -> IO ()
 benchCommands commands opts@Options{..} = do


### PR DESCRIPTION
Hi Gabriel,

This is more of a proof of concept to support benchmarking of one command or multiple commands. If you do like the PR, I imagine you'd want to change/fix some things in the code, especially the Read instance.

These changes maintain backwards compatibility. Here is an example usage:

## single command
```
stack exec -- bench "cat /etc/motd | wc -l"
```

## multiple commands
```
stack exec -- bench '["id", "ls", "sleep 0.1"]' --output > /tmp/output.html
```

## example output for multiple commands
```
bench $ stack exec -- bench '["id", "ls", "sleep 0.1"]' --output /tmp/output.html
benchmarking bench/id
time                 4.852 ms   (4.812 ms .. 4.894 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 4.960 ms   (4.913 ms .. 5.043 ms)
std dev              197.2 μs   (106.6 μs .. 368.9 μs)
variance introduced by outliers: 21% (moderately inflated)

benchmarking bench/ls
time                 3.048 ms   (2.981 ms .. 3.135 ms)
                     0.990 R²   (0.977 R² .. 0.998 R²)
mean                 3.044 ms   (2.998 ms .. 3.139 ms)
std dev              203.9 μs   (102.2 μs .. 352.9 μs)
variance introduced by outliers: 46% (moderately inflated)

benchmarking bench/sleep 0.1
time                 109.5 ms   (108.9 ms .. 110.4 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 109.0 ms   (108.3 ms .. 109.5 ms)
std dev              858.5 μs   (385.1 μs .. 1.372 ms)
```

The HTML output is even nicer, because it also has that summary at the top with everything that has been benched, then each benchmark has its own section. Also If you notice, I hardcoded "bench" as the bgroup name (for now?).

I'm already using it to create benchmarks of several parsing libraries:
- https://github.com/adarqui/cardiac-arrest/tree/master/experiments/parsing/big-strings/purescript#results


Thanks!

Andrew