### PR TITLE
Bump version bound on turtle

### DIFF
--- a/bench.cabal
+++ b/bench.cabal
@@ -30,5 +30,5 @@ executable bench
                      , optparse-applicative >= 0.2.0   && < 0.14
                      , silently             >= 1.1.1   && < 1.3
                      , text                               < 1.3
-                     , turtle               >= 1.2.5   && < 1.3
+                     , turtle               >= 1.2.5   && < 1.4
   ghc-options:         -Wall -O2 -threaded


### PR DESCRIPTION
`bench` still compiles with `turtle-1.3.1`, so I expanded the version bound.