### PR TITLE
Close standard input when benchmarking programs

### DIFF
--- a/bench.cabal
+++ b/bench.cabal
@@ -28,6 +28,7 @@ executable bench
   build-depends:       base                 >= 4.5     && < 5
                      , criterion            >= 1.1.1.0 && < 1.3
                      , optparse-applicative >= 0.2.0   && < 0.15
+                     , process              >= 1.0.1.1 && < 1.7
                      , silently             >= 1.1.1   && < 1.3
                      , text                               < 1.3
                      , turtle               >= 1.2.5   && < 1.5

--- a/bench.cabal
+++ b/bench.cabal
@@ -28,7 +28,7 @@ executable bench
   build-depends:       base                 >= 4.5     && < 5
                      , criterion            >= 1.1.1.0 && < 1.3
                      , optparse-applicative >= 0.2.0   && < 0.15
-                     , process              >= 1.0.1.1 && < 1.7
+                     , process              >= 1.3     && < 1.7
                      , silently             >= 1.1.1   && < 1.3
                      , text                               < 1.3
                      , turtle               >= 1.2.5   && < 1.5

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, criterion, optparse-applicative, silently
-, stdenv, text, turtle
+{ mkDerivation, base, criterion, optparse-applicative, process
+, silently, stdenv, text, turtle
 }:
 mkDerivation {
   pname = "bench";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
-    base criterion optparse-applicative silently text turtle
+    base criterion optparse-applicative process silently text turtle
   ];
   homepage = "http://github.com/Gabriel439/bench";
   description = "Command-line benchmark tool";

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,1 @@
-resolver: lts-5.8
-packages:
-- .
+resolver: lts-9.6


### PR DESCRIPTION
Fixes #14

Some programs (such as `ack`) behave differently if you feed them an empty
input stream as opposed to a closed input stream.  Previously `bench` would
feed programs an empty input stream (i.e. analogous to `: | program`) and after
this change `bench` gives them a closed input stream