### PR TITLE
Add Homebrew installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Key features:
 
 ## Quick Start
 
-You can download a pre-built binary for OS X on the releases page:
+You can install `bench` on macOS via [Homebrew](http://braumeister.org/formula/bench):
 
-* https://github.com/Gabriel439/bench/releases
+```bash
+$ brew install bench
+```
 
 ... or you can install `bench` using Haskell's `stack` tool.  To do that, first
 download the [Haskell toolchain](https://www.haskell.org/downloads#minimal),


### PR DESCRIPTION
I just [added bench to Homebrew](https://github.com/Homebrew/homebrew-core/pull/19215). I would be nice to mention that on README.

I also removed the mention of pre-built binaries since it seems that releases are no longer tagged or no longer pushed to GitHub, let alone binaries.