### PR TITLE
stack.yaml: update to lts-10.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.6
+resolver: lts-10.0
 packages:
 - .
 - location:
@@ -8,5 +8,3 @@ packages:
 flags:
   criterion:
     embed-data-files: true
-extra-deps:
-- statistics-0.14.0.2


### PR DESCRIPTION
Tried building with stack (for a change) and, since stack's ghc bindists do not work here, I updated stack.yaml to lts-10.0 in order to use the host GHC (8.2.2).